### PR TITLE
mapstruct upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <springboot.version>2.2.5.RELEASE</springboot.version>
         <tensorflow.version>1.12.0</tensorflow.version>
         <es.version>7.6.1</es.version>
-        <mapstruct.version>1.3.1.Final</mapstruct.version>
+        <mapstruct.version>1.4.1.Final</mapstruct.version>
     </properties>
 
 
@@ -248,12 +248,7 @@
             <!-- MapStruct START -->
             <dependency>
                 <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-jdk8</artifactId>
-                <version>${mapstruct.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
+                <artifactId>mapstruct</artifactId>
                 <version>${mapstruct.version}</version>
             </dependency>
             <!-- MapStruct  end -->

--- a/radar-dal/pom.xml
+++ b/radar-dal/pom.xml
@@ -30,11 +30,7 @@
         <!-- MapStruct START -->
         <dependency>
             <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-jdk8</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct-processor</artifactId>
+            <artifactId>mapstruct</artifactId>
         </dependency>
         <!-- MapStruct  end -->
     </dependencies>
@@ -45,6 +41,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source> <!-- depending on your project -->
+                    <target>${java.version}</target> <!-- depending on your project -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <!-- other annotation processors -->
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/radar-dal/src/main/java/com/pgmmers/radar/mapstruct/AbstractionMapping.java
+++ b/radar-dal/src/main/java/com/pgmmers/radar/mapstruct/AbstractionMapping.java
@@ -8,7 +8,7 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface AbstractionMapping extends BaseMapping<AbstractionPO, AbstractionVO> {
 
-    @Mapping(target = "dataCollectionNames", source = "")
+    @Mapping(target = "dataCollectionNames", ignore = true)
     @Mapping(target = "ruleDefinition", expression = "java(com.pgmmers.radar.util.JsonUtils.getJsonNode(var1.getRuleDefinition()))")
     @Override
     AbstractionVO sourceToTarget(AbstractionPO var1);


### PR DESCRIPTION
mapstruct upgrade
idea 升级至2020.2.3 导致build 失败 [mapstruct issues](https://github.com/mapstruct/mapstruct/issues/2215)
 idea  请启用annotation processors 以及安装 mapstruct 插件 配合mapstruct使用
